### PR TITLE
Add tvOS to podspec

### DIFF
--- a/PathKit.podspec
+++ b/PathKit.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |spec|
   spec.source_files = 'Sources/PathKit.swift'
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.9'
+  spec.tvos.deployment_target = '9.0'
   spec.requires_arc = true
 end
-


### PR DESCRIPTION
Add support for tvOS to the pod spec.

I've ran `pod lib lint` and tried it manually in tvOS project, no complaints.