### PR TITLE
Making sure test for path with tilde passes if test is run under root

### DIFF
--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -86,8 +86,6 @@ describe("PathKit") {
     $0.describe("a relative path with tilde") {
       let path = Path("~")
 
-	  print("Username = \(NSUserName())")
-
       $0.it("can be converted to an absolute path") {
         #if os(Linux)
           if NSUserName() == "root" {

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -86,9 +86,16 @@ describe("PathKit") {
     $0.describe("a relative path with tilde") {
       let path = Path("~")
 
+	  print("Username = \(NSUserName())")
+
       $0.it("can be converted to an absolute path") {
         #if os(Linux)
-          try expect(path.absolute()) == "/home/" + NSUserName()
+          if NSUserName() == "root" {
+            try expect(path.absolute()) == "/root"		
+          }
+          else {
+            try expect(path.absolute()) == "/home/" + NSUserName()
+          }
         #else
           try expect(path.absolute()) == "/Users/" + NSUserName()
         #endif


### PR DESCRIPTION
On Linux normal users home folders are under /home folder, but for root it is /root. This makes sure, the test for path with tilde passes in case test is run under root.

@kylef Please review and merge. And please bump project to 0.7.2 version (tag). Thank you.