### PR TITLE
Enumeration with options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+
+---
+
+## unreleased
+
+* Additional method for creating an iterator with options.  
+  [#25](https://github.com/kylef/PathKit/pull/23)
+
 ## 0.7.0
 
-Adds support for Swift 3.0
+* Adds support for Swift 3.0

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -587,6 +587,17 @@ extension Path {
 // MARK: SequenceType
 
 extension Path : Sequence {
+  public struct DirectoryEnumerationOptions : OptionSet {
+    public let rawValue: UInt
+    public init(rawValue: UInt) {
+      self.rawValue = rawValue
+    }
+
+    public static var skipsSubdirectoryDescendants = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsSubdirectoryDescendants.rawValue)
+    public static var skipsPackageDescendants = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsPackageDescendants.rawValue)
+    public static var skipsHiddenFiles = DirectoryEnumerationOptions(rawValue: FileManager.DirectoryEnumerationOptions.skipsHiddenFiles.rawValue)
+  }
+  
   /// Enumerates the contents of a directory, returning the paths of all files and directories
   /// contained within that directory. These paths are relative to the directory.
   public struct DirectoryEnumerator : IteratorProtocol {
@@ -600,7 +611,8 @@ extension Path : Sequence {
       self.directoryEnumerator = Path.fileManager.enumerator(atPath: path.path)!
     }
     
-    init(path: Path, options: FileManager.DirectoryEnumerationOptions) {
+    init(path: Path, options mask: DirectoryEnumerationOptions) {
+      let options = FileManager.DirectoryEnumerationOptions(rawValue: mask.rawValue)
       self.path = path
       self.directoryEnumerator = Path.fileManager.enumerator(at: path.url, includingPropertiesForKeys: nil, options: options)!
     }
@@ -638,7 +650,7 @@ extension Path : Sequence {
   /// - Returns: a directory enumerator that can be used to perform a deep enumeration of the
   ///   directory.
   ///
-  public func makeIterator(options: FileManager.DirectoryEnumerationOptions) -> DirectoryEnumerator {
+  public func makeIterator(options: DirectoryEnumerationOptions) -> DirectoryEnumerator {
     return DirectoryEnumerator(path: self, options: options)
   }
 }

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -599,10 +599,19 @@ extension Path : Sequence {
       self.path = path
       self.directoryEnumerator = Path.fileManager.enumerator(atPath: path.path)!
     }
+    
+    init(path: Path, options: FileManager.DirectoryEnumerationOptions) {
+      self.path = path
+      self.directoryEnumerator = Path.fileManager.enumerator(at: URL(fileURLWithPath: path.path), includingPropertiesForKeys: nil, options: options)!
+    }
 
     public func next() -> Path? {
-      if let next = directoryEnumerator.nextObject() as! String? {
+      let next = directoryEnumerator.nextObject()
+      
+      if let next = next as? String {
         return path + next
+      } else if let next = next as? URL {
+        return Path(next.path)
       }
       return nil
     }
@@ -620,6 +629,17 @@ extension Path : Sequence {
   ///
   public func makeIterator() -> DirectoryEnumerator {
     return DirectoryEnumerator(path: self)
+  }
+
+  /// Perform a deep enumeration of a directory.
+  ///
+  /// - Parameter options: FileManager directory enumerator options.
+  ///
+  /// - Returns: a directory enumerator that can be used to perform a deep enumeration of the
+  ///   directory.
+  ///
+  public func makeIterator(options: FileManager.DirectoryEnumerationOptions) -> DirectoryEnumerator {
+    return DirectoryEnumerator(path: self, options: options)
   }
 }
 

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -602,7 +602,7 @@ extension Path : Sequence {
     
     init(path: Path, options: FileManager.DirectoryEnumerationOptions) {
       self.path = path
-      self.directoryEnumerator = Path.fileManager.enumerator(at: URL(fileURLWithPath: path.path), includingPropertiesForKeys: nil, options: options)!
+      self.directoryEnumerator = Path.fileManager.enumerator(at: path.url, includingPropertiesForKeys: nil, options: options)!
     }
 
     public func next() -> Path? {

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -400,7 +400,7 @@ describe("PathKit") {
       #else
       let path = fixtures + "directory"
       var children = ["child", "subdirectory"].map { path + $0 }
-      let generator = path.makeIterator(options: .skipsHiddenFiles)
+      let generator = path.iterateChildren(options: .skipsHiddenFiles).makeIterator()
       while let child = generator.next() {
         generator.skipDescendants()
         if let index = children.index(of: child) {

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -369,28 +369,50 @@ describe("PathKit") {
   $0.it("can return the recursive children") {
     let parent = fixtures + "directory"
     let children = try parent.recursiveChildren().sorted(by: <)
-    let expected = ["child", "subdirectory", "subdirectory/child"].map { parent + $0 }.sorted(by: <)
+    let expected = [".hiddenFile", "child", "subdirectory", "subdirectory/child"].map { parent + $0 }.sorted(by: <)
     try expect(children) == expected
   }
 
-  $0.it("conforms to SequenceType") {
-    #if os(Linux)
-    throw skip()
-    #else
-    let path = fixtures + "directory"
-    var children = ["child", "subdirectory"].map { path + $0 }
-    let generator = path.makeIterator()
-    while let child = generator.next() {
-      generator.skipDescendants()
-      if let index = children.index(of: child) {
-        children.remove(at: index)
-      } else {
-        throw failure("Generated unexpected element: <\(child)>")
+  $0.describe("conforms to SequenceType") {
+    $0.it("without options") {
+      #if os(Linux)
+      throw skip()
+      #else
+      let path = fixtures + "directory"
+      var children = ["child", "subdirectory", ".hiddenFile"].map { path + $0 }
+      let generator = path.makeIterator()
+      while let child = generator.next() {
+        generator.skipDescendants()
+        if let index = children.index(of: child) {
+          children.remove(at: index)
+        } else {
+          throw failure("Generated unexpected element: <\(child)>")
+        }
       }
-    }
 
-    try expect(children.isEmpty).to.beTrue()
-    #endif
+      try expect(children.isEmpty).to.beTrue()
+      #endif
+    }
+  
+    $0.it("with options") {
+      #if os(Linux)
+      throw skip()
+      #else
+      let path = fixtures + "directory"
+      var children = ["child", "subdirectory"].map { path + $0 }
+      let generator = path.makeIterator(options: .skipsHiddenFiles)
+      while let child = generator.next() {
+        generator.skipDescendants()
+        if let index = children.index(of: child) {
+          children.remove(at: index)
+        } else {
+          throw failure("Generated unexpected element: <\(child)>")
+        }
+      }
+
+      try expect(children.isEmpty).to.beTrue()
+      #endif
+    }
   }
 
   $0.it("can be pattern matched") {


### PR DESCRIPTION
The current enumerator (from `makeIterator`) does not support advanced options. This PR simply adds this + the necessary unit test.