### PR TITLE
String and URL accessors

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -83,7 +83,7 @@ extension Path {
   }
 
   public var url: URL {
-	return URL(fileURLWithPath: path)
+    return URL(fileURLWithPath: path)
   }
 }
 
@@ -125,10 +125,10 @@ extension Path {
       return normalize()
     }
 
-	let expandedPath = Path(NSString(string: self.path).expandingTildeInPath)
-	if expandedPath.isAbsolute {
-		return expandedPath.normalize()
-	}
+  let expandedPath = Path(NSString(string: self.path).expandingTildeInPath)
+  if expandedPath.isAbsolute {
+    return expandedPath.normalize()
+  }
 
     return (Path.current + self).normalize()
   }

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -67,6 +67,7 @@ extension Path : ExpressibleByStringLiteral {
   }
 }
 
+
 // MARK: CustomStringConvertible
 
 extension Path : CustomStringConvertible {
@@ -74,6 +75,7 @@ extension Path : CustomStringConvertible {
     return self.path
   }
 }
+
 
 // MARK: Conversion
 

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -468,7 +468,7 @@ extension Path {
   /// - Returns: the contents of the file at the specified path.
   ///
   public func read() throws -> Data {
-    return try Data(contentsOf: URL(fileURLWithPath: path), options: NSData.ReadingOptions(rawValue: 0))
+    return try Data(contentsOf: self.url, options: NSData.ReadingOptions(rawValue: 0))
   }
 
   /// Reads the file contents and encoded its bytes to string applying the given encoding.
@@ -490,7 +490,7 @@ extension Path {
   /// - Parameter data: the contents to write to file.
   ///
   public func write(_ data: Data) throws {
-    try data.write(to: URL(fileURLWithPath: normalize().path), options: .atomic)
+    try data.write(to: normalize().url, options: .atomic)
   }
 
   /// Reads the file.

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -67,12 +67,23 @@ extension Path : ExpressibleByStringLiteral {
   }
 }
 
-
 // MARK: CustomStringConvertible
 
 extension Path : CustomStringConvertible {
   public var description: String {
     return self.path
+  }
+}
+
+// MARK: Conversion
+
+extension Path {
+  public var string: String {
+    return self.path
+  }
+
+  public var url: URL {
+	return URL(fileURLWithPath: path)
   }
 }
 

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -45,8 +45,16 @@ describe("PathKit") {
       try expect(path.description) == "/usr/bin/swift"
     }
 
-    $0.it("can be converted to a string") {
+    $0.it("can be converted to a string description") {
       try expect(Path("/usr/bin/swift").description) == "/usr/bin/swift"
+    }
+    
+    $0.it("can be converted to a string") {
+      try expect(Path("/usr/bin/swift").string) == "/usr/bin/swift"
+    }
+    
+    $0.it("can be converted to a url") {
+      try expect(Path("/usr/bin/swift").url) == URL(fileURLWithPath: "/usr/bin/swift")
     }
   }
 


### PR DESCRIPTION
Currently, the only way to convert a `Path` instance to a `String` or `URL` is:
```swift
let s = String(describing: path) // or path.description
let u = URL(fileURLWithPath: path.description)
```
Which is a bit hacky. There will always be instances where we need to access either of those representations. Using the `description` of a path feels more like a debug representation, prone to future changes.

I've added accessors for both representations, but a better name for the properties is definitely welcome.