### PR TITLE
Use `.git` extension on dependencies URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
   name: "PathKit",
   dependencies: [
     // https://github.com/apple/swift-package-manager/pull/597
-    .Package(url: "https://github.com/kylef/Spectre", majorVersion: 0, minor: 7),
+    .Package(url: "https://github.com/kylef/Spectre.git", majorVersion: 0, minor: 7),
   ]
 )


### PR DESCRIPTION
https://github.com/kylef/Commander/commit/4c320a3507d621d27f89514eb576664becfee643 broke support for using latest versions of PathKit and Commander in one SwiftPM project.

```
error: rename error: Directory not empty (66): /path/to/Packages/Spectre.git -> /path/to/Packages/Spectre-0.7.2
```