### PR TITLE
Treat non-existing directory as an empty sequence.

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -651,16 +651,16 @@ extension Path : Sequence {
     public typealias Element = Path
 
     let path: Path
-    let directoryEnumerator: FileManager.DirectoryEnumerator
+    let directoryEnumerator: FileManager.DirectoryEnumerator?
 
     init(path: Path, options mask: DirectoryEnumerationOptions = []) {
       let options = FileManager.DirectoryEnumerationOptions(rawValue: mask.rawValue)
       self.path = path
-      self.directoryEnumerator = Path.fileManager.enumerator(at: path.url, includingPropertiesForKeys: nil, options: options)!
+      self.directoryEnumerator = Path.fileManager.enumerator(at: path.url, includingPropertiesForKeys: nil, options: options)
     }
 
     public func next() -> Path? {
-      let next = directoryEnumerator.nextObject()
+      let next = directoryEnumerator?.nextObject()
       
       if let next = next as? URL {
         return Path(next.path)
@@ -670,7 +670,7 @@ extension Path : Sequence {
 
     /// Skip recursion into the most recently obtained subdirectory.
     public func skipDescendants() {
-      directoryEnumerator.skipDescendants()
+      directoryEnumerator?.skipDescendants()
     }
   }
 

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -426,6 +426,7 @@ describe("PathKit") {
       }
 
       try expect(children.isEmpty).to.beTrue()
+      try expect(Path("/non/existing/directory/path").makeIterator().next()).to.beNil()
       #endif
     }
   
@@ -446,6 +447,7 @@ describe("PathKit") {
       }
 
       try expect(children.isEmpty).to.beTrue()
+      try expect(Path("/non/existing/directory/path").makeIterator().next()).to.beNil()
       #endif
     }
   }


### PR DESCRIPTION
When a Path is created for a directory that does not exist, and you call one of the Sequence methods, you get a crash because `FileManager.enumerator(atPath:)` is forcibly unwrapped in the initializer of `DirectoryEnumerator`.

Ideally, there would be a way for a strongly typed error to be thrown, if you see this as an error condition, but I don't see a nice way to do that through `IteratorProtocol` or `Sequence`.

However, just making it behave as an empty sequence might be more preferable, or reporting a friendlier error message.