### PR TITLE
Combining paths . and ../foo/baz returns correct result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PathKit Changelog
 
+## Master
+
+### Bug Fixes
+
+* Appending to (.) slice started with (..) will return correct path.  
+  [Antondomashnev](https://github.com/Antondomashnev)
+
+
 ## 0.8.0
 
 ### Enhancements

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -765,8 +765,8 @@ internal func +(lhs: String, rhs: String) -> Path {
     rSlice = rSlice.filter { $0 != "." }.fullSlice
 
     // Eats up trailing components of the left and leading ".." of the right side
-    while lSlice.last != ".." && rSlice.first == ".." {
-      if (lSlice.count > 1 || lSlice.first != Path.separator) && !lSlice.isEmpty {
+    while lSlice.last != ".." && !lSlice.isEmpty && rSlice.first == ".." {
+      if lSlice.count > 1 || lSlice.first != Path.separator {
         // A leading "/" is never popped
         lSlice.removeLast()
       }

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -480,6 +480,8 @@ describe("PathKit") {
     try expect(Path("a")) == "./." + "a"
     try expect(Path(".")) == "." + "."
     try expect(Path(".")) == "./." + "./."
+    try expect(Path("../a")) == "." + "./../a"
+    try expect(Path("../a")) == "." + "../a"
 
     // Appending (to) '..'
     try expect(Path(".")) == "a" + ".."


### PR DESCRIPTION
The PR resolved the reported issue #35.
@kylef I've updated changelog, please let me know if that is expected style.