### PR TITLE
Removing String's deprecated APIs and modifying for Swift 4

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -42,7 +42,7 @@ public struct Path {
       path = "."
     } else if components.first == Path.separator && components.count > 1 {
       let p = components.joined(separator: Path.separator)
-      path = p.substring(from: p.characters.index(after: p.startIndex))
+      path = String (p[p.index(after: p.startIndex)...])
     } else {
       path = components.joined(separator: Path.separator)
     }


### PR DESCRIPTION
Removed use of `substring(from)` api and updated for new syntax.