### PR TITLE
Update Tests For .lastComponentWithoutExetnison

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -221,7 +221,7 @@ extension Path {
 
   /// The last path component without file extension
   ///
-  /// - Note: This returns "." for "..".
+  /// - Note: This returns "." for ".." on Linux, and ".." on Apple platforms.
   ///
   /// - Returns: the last path component without file extension
   ///

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -210,7 +210,11 @@ describe("PathKit") {
 
   $0.it("can return the last component without extension") {
     try expect(Path("a/b/c.d").lastComponentWithoutExtension) == "c"
-    try expect(Path("a/..").lastComponentWithoutExtension) == "."
+    #if os(Linux) // no longer necessary after Swift 4.1
+        try expect(Path("a/..").lastComponentWithoutExtension) == "."
+    #else
+        try expect(Path("a/..").lastComponentWithoutExtension) == ".."
+    #endif
   }
 
   $0.it("can be split into components") {


### PR DESCRIPTION
_Background_

A test for this API has been [failing, but only on macOS][0]. This is
due to a implementation difference between the closed-source Foundation
and its open-source counterpart. Recently, a [patch][1] has been made to
the latter to fix this issue. The patch is [included][2] in the upcoming
Swift 4.1 release.

_Changes_

Add a condition to the test so it passes on both platforms for now. The
expectation is that come Swift 4.1, this test will start failing on
Linux and the condition will be removed then.

[0]: https://travis-ci.org/kylef/PathKit/builds/289637066
[1]: https://github.com/apple/swift-corelibs-foundation/pull/1376
[2]: https://github.com/apple/swift-corelibs-foundation/commits/swift-4.1-branch