### PR TITLE
Removed character reference for Swift 4.0.3 support

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -42,7 +42,7 @@ public struct Path {
       path = "."
     } else if components.first == Path.separator && components.count > 1 {
       let p = components.joined(separator: Path.separator)
-      path = p.substring(from: p.characters.index(after: p.startIndex))
+      path = p.substring(from: p.index(after: p.startIndex))
     } else {
       path = components.joined(separator: Path.separator)
     }


### PR DESCRIPTION
A small PR just to remove the reference to character, which gives warnings in Swift 4.0.3. Tests all passing and builds successfully.