### PR TITLE
Support Swift versions 3.1 through 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,24 @@
-os:
-- linux
-- osx
-language: generic
-sudo: required
-dist: trusty
-osx_image: xcode9
+matrix:
+  include:
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+      env: SWIFT_VERSION=3.1.1
+    - os: linux
+      language: generic
+      sudo: required
+      dist: trusty
+    - os: osx
+      language: generic
+      sudo: required
+      osx_image: xcode8.3
+      env: SWIFT_VERSION=3.1.1
+    - os: osx
+      language: generic
+      sudo: required
+      osx_image: xcode9
+
 install:
 - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
 script:

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,9 @@
-// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
   name: "PathKit",
-  products: [
-    .library(name: "PathKit", targets: ["PathKit"]),
-  ],
   dependencies: [
-    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.8.0"))
-  ],
-  targets: [
-    .target(name: "PathKit", dependencies: [], path: "Sources"),
-    .testTarget(name: "PathKitTests", dependencies: ["PathKit", "Spectre"], path:"Tests/PathKitTests")
-  ],
-  swiftLanguageVersions: [3]
+    // https://github.com/apple/swift-package-manager/pull/597
+    .Package(url: "https://github.com/kylef/Spectre.git", majorVersion: 0, minor: 7),
+  ]
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+  name: "PathKit",
+  products: [
+    .library(name: "PathKit", targets: ["PathKit"]),
+  ],
+  dependencies: [
+    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.8.0"))
+  ],
+  targets: [
+    .target(name: "PathKit", dependencies: [], path: "Sources"),
+    .testTarget(name: "PathKitTests", dependencies: ["PathKit", "Spectre"], path:"Tests/PathKitTests")
+  ]
+)

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -210,10 +210,10 @@ describe("PathKit") {
 
   $0.it("can return the last component without extension") {
     try expect(Path("a/b/c.d").lastComponentWithoutExtension) == "c"
-    #if os(Linux) // no longer necessary after Swift 4.1
-        try expect(Path("a/..").lastComponentWithoutExtension) == "."
-    #else
+    #if !os(Linux) || swift(>=4.1)
         try expect(Path("a/..").lastComponentWithoutExtension) == ".."
+    #else
+        try expect(Path("a/..").lastComponentWithoutExtension) == "."
     #endif
   }
 


### PR DESCRIPTION
Changes to allow PathKit to build on Swift 3.1, 4.0 and 4.1:
- Support Swift 3.1 through 4.1 by reintroducing the Swift 3 format Package.swift from 0.8.0, and renaming the Swift 4 format to `Package@swift-4.swift`
- Remove deprecation warnings for String API changes in Swift 4 - similar to #42 / #45, but guarded to maintain compatibility with Swift 3
- Address compilation error on Linux + Swift 4.1 due to https://github.com/apple/swift-corelibs-foundation/pull/1223
- Update `lastComponentWithoutExtension` test for Linux + Swift 4.1
- Add travis matrix for testing with both Swift 3.1.1 and 4.0 snapshots (I didn't add a 4.1 dev snapshot, but this would be straightforward)