### PR TITLE
Opened test to non-Darwin platforms

### DIFF
--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -418,7 +418,7 @@ describe("PathKit") {
 
   $0.describe("conforms to SequenceType") {
     $0.it("without options") {
-      #if os(Linux)
+      #if !os(Darwin) && !swift(>=4.1)
       throw skip()
       #else
       let path = fixtures + "directory"


### PR DESCRIPTION
Detail: opened
`conforms to SequenceType`.`without options`

Put up a restriction over Swift version to maintain backwards compatibility.