### PR TITLE
Update test structure for Spectre 0.9

### DIFF
--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -7,8 +7,7 @@ struct ThrowError: Error, Equatable {}
 func == (lhs:ThrowError, rhs:ThrowError) -> Bool { return true }
 
 
-public func testPathKit() {
-describe("PathKit") {
+public let testPathKit: ((ContextType) -> Void) = {
   let fixtures = Path(#file).parent() + "Fixtures"
 
   $0.before {
@@ -517,5 +516,4 @@ describe("PathKit") {
       try expect(paths) == results.sorted(by: <)
     }
   }
-}
 }

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -417,7 +417,7 @@ public let testPathKit: ((ContextType) -> Void) = {
 
   $0.describe("conforms to SequenceType") {
     $0.it("without options") {
-      #if !os(Darwin) && !swift(>=4.1)
+      #if !os(macOS) && !swift(>=4.1)
       throw skip()
       #else
       let path = fixtures + "directory"

--- a/Tests/PathKitTests/XCTest.swift
+++ b/Tests/PathKitTests/XCTest.swift
@@ -2,6 +2,6 @@ import XCTest
 
 class PathKitTests: XCTestCase {
   func testRunSpectre() {
-    testPathKit()
+    describe("PathKit", testPathKit)
   }
 }


### PR DESCRIPTION
Upgrades the tests to match the examples shown in kylef/Spectre#32.