### PR TITLE
Update for Swift 4.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 matrix:
   include:
+    - os: linux	
+      language: generic	
+      sudo: required	
+      dist: trusty	
+      env:	
+        - SWIFT_VERSION=4.2.1
+        - MAJOR_VERSION=4.2
     - os: linux
       language: generic
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       sudo: required
       osx_image: xcode10
       env:
-        - SWIFT_VERSION=4.2
+        - SWIFT_VERSION=4.2.1
         - MAJOR_VERSION=4.2
     - os: osx
       language: generic


### PR DESCRIPTION
This adds Linux support for Swift 4.2.1.

GH-56 attempted to add Swift 4.2 support for linux as well as OSX but a bug upstream prevented it at that time. Looks like that bug has been fixed in 4.2.1, I think here - https://github.com/apple/swift-corelibs-foundation/pull/1670

This may also address GH-50