### PR TITLE
Replace all internal var with let

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -19,11 +19,11 @@ public struct Path {
   public static let separator = "/"
 
   /// The underlying string representation
-  internal var path: String
+  internal let path: String
 
-  internal static var fileManager = FileManager.default
+  internal static let fileManager = FileManager.default
   
-  internal var fileSystemInfo: FileSystemInfo = DefaultFileSystemInfo()
+  internal let fileSystemInfo: FileSystemInfo = DefaultFileSystemInfo()
 
   // MARK: Init
 

--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -23,21 +23,31 @@ public struct Path {
 
   internal static let fileManager = FileManager.default
   
-  internal let fileSystemInfo: FileSystemInfo = DefaultFileSystemInfo()
+  internal let fileSystemInfo: FileSystemInfo
 
   // MARK: Init
 
   public init() {
-    self.path = ""
+    self.init("")
   }
 
   /// Create a Path from a given String
   public init(_ path: String) {
+    self.init(path, fileSystemInfo: DefaultFileSystemInfo())
+  }
+    
+  internal init(_ path: String, fileSystemInfo: FileSystemInfo) {
     self.path = path
+    self.fileSystemInfo = fileSystemInfo
   }
 
+  internal init(fileSystemInfo: FileSystemInfo) {
+    self.init("", fileSystemInfo: fileSystemInfo)
+  }
+    
   /// Create a Path by joining multiple path components together
   public init<S : Collection>(components: S) where S.Iterator.Element == String {
+    let path: String
     if components.isEmpty {
       path = "."
     } else if components.first == Path.separator && components.count > 1 {
@@ -46,6 +56,7 @@ public struct Path {
     } else {
       path = components.joined(separator: Path.separator)
     }
+    self.init(path)
   }
 }
 
@@ -65,7 +76,7 @@ extension Path : ExpressibleByStringLiteral {
   }
 
   public init(stringLiteral value: StringLiteralType) {
-    self.path = value
+    self.init(value)
   }
 }
 

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -167,8 +167,7 @@ describe("PathKit") {
   $0.it("can abbreviate paths on a case sensitive fs") {
     let home = Path.home.string
     let fakeFSInfo = FakeFSInfo(caseSensitive: true)
-    var path = Path("\(home.uppercased())")
-    path.fileSystemInfo = fakeFSInfo
+    let path = Path("\(home.uppercased())", fileSystemInfo: fakeFSInfo)
     
     try expect(path.abbreviate().string) == home.uppercased()
   }
@@ -176,8 +175,7 @@ describe("PathKit") {
   $0.it("can abbreviate paths on a case insensitive fs") {
     let home = Path.home.string
     let fakeFSInfo = FakeFSInfo(caseSensitive: false)
-    var path = Path("\(home.uppercased())")
-    path.fileSystemInfo = fakeFSInfo
+    let path = Path("\(home.uppercased())", fileSystemInfo: fakeFSInfo)
     
     try expect(path.abbreviate()) == Path("~")
   }


### PR DESCRIPTION
Hello.
Thank you for PathKit.
In this pull request I replaced all `internal` `var` with `let` because all such properties are not mutable. To fix compile errors I added new `init` functions.