### PR TITLE
Added Codable support

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -60,6 +60,22 @@ public struct Path {
   }
 }
 
+// MARK: Codable
+
+extension Path : Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(path)
+  }
+}
+
+extension Path : Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let decodedString = try container.decode(String.self)
+    self.init(decodedString)
+  }
+}
 
 // MARK: StringLiteralConvertible
 


### PR DESCRIPTION
Demo:

``` swift
import PathKit
import Foundation

struct Container: Codable {
  let path: Path
}

let decoder = JSONDecoder()

let string = """
  {
    "path": "/usr/bin/swift"
  }
"""

let container = try decoder.decode(Container.self, from: string.data(using: .utf8)!)
print(container.path.description)

let encoder = JSONEncoder()
let result = try encoder.encode(container)

print(String(data: result, encoding: .utf8)!)
```

I've love to add tests, but the test target keeps giving this error:

![Screen Shot 2021-02-07 at 16 33 44](https://user-images.githubusercontent.com/229384/107151328-45947200-6962-11eb-9798-2fe12d29e42a.png)

Not sure why, as the Spectre dependency is downloaded by Xcode just fine.