### PR TITLE
Update Spectre to 0.10.0 for Xcode 12.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     .library(name: "PathKit", targets: ["PathKit"]),
   ],
   dependencies: [
-    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.9.0"))
+    .package(url:"https://github.com/kylef/Spectre.git", .upToNextMinor(from:"0.10.0"))
   ],
   targets: [
     .target(name: "PathKit", dependencies: [], path: "Sources"),


### PR DESCRIPTION
This updates Spectre to the recent 0.10.0 release. Without this packages that use both PathKit and Spectre can't update Spectre, and therefore are broken in Xcode 12.5