### PR TITLE
Update `.travis.yml` to use updated build environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,21 +21,28 @@ matrix:
     - os: osx
       language: generic
       sudo: required
-      osx_image: xcode10
+      osx_image: xcode10.3
       env:
         - SWIFT_VERSION=4.2
         - MAJOR_VERSION=4.2
     - os: osx
       language: generic
       sudo: required
-      osx_image: xcode10.2
+      osx_image: xcode10.3
       env:
-        - SWIFT_VERSION=4.2
-        - MAJOR_VERSION=4.2
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
     - os: osx
       language: generic
       sudo: required
-      osx_image: xcode10.2
+      osx_image: xcode11.6
+      env:
+        - SWIFT_VERSION=5.0
+        - MAJOR_VERSION=5
+    - os: osx
+      language: generic
+      sudo: required
+      osx_image: xcode12.5
       env:
         - SWIFT_VERSION=5.0
         - MAJOR_VERSION=5


### PR DESCRIPTION
Related: https://docs.travis-ci.com/user/reference/osx/

I came looking for an updated version of PathKit that worked with Xcode 12.5 (1.0.0 is limited because of kylef/Spectre#46) but noticed that it had already been patched in #74. I was going to raise an issue asking for a 1.0.1 release, but I also spotted that **.travis.yml** could do with a little refresh so here we are 🙂 

After considering this change, it would be great if you could do a release so that I have a tag to point to 🙏 

Thanks for the hard work!

