### PR TITLE
fix build on Xcode 13 RC

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -587,8 +587,8 @@ extension Path {
 
 extension Path {
   public static func glob(_ pattern: String) -> [Path] {
+    guard let cPattern = strdup(pattern) else { return [] }
     var gt = glob_t()
-    let cPattern = strdup(pattern)
     defer {
       globfree(&gt)
       free(cPattern)
@@ -619,8 +619,7 @@ extension Path {
   }
 
   public func match(_ pattern: String) -> Bool {
-    let cPattern = strdup(pattern)
-    let cPath = strdup(path)
+    guard let cPattern = strdup(pattern), let cPath = strdup(path) else { return false }
     defer {
       free(cPattern)
       free(cPath)


### PR DESCRIPTION
This fixes the build of PathKit on Xcode 13 RC.

`strdup` returns an implicitly unwrapped optional, which seems to loose its "implicit" via the assignment.
I couldn't find anything in the Xcode release notes, but I guess it's a fair change :-)
Let's treat the returned pointers as true optionals and instead of crashing, return defaults.