### PR TITLE
Xcode 13 Hotfix

### DIFF
--- a/Sources/PathKit.swift
+++ b/Sources/PathKit.swift
@@ -588,7 +588,9 @@ extension Path {
 extension Path {
   public static func glob(_ pattern: String) -> [Path] {
     var gt = glob_t()
-    let cPattern = strdup(pattern)
+    guard let cPattern = strdup(pattern) else {
+      fatalError("strdup returned null: Likely out of memory")
+    }
     defer {
       globfree(&gt)
       free(cPattern)
@@ -619,8 +621,10 @@ extension Path {
   }
 
   public func match(_ pattern: String) -> Bool {
-    let cPattern = strdup(pattern)
-    let cPath = strdup(path)
+    guard let cPattern = strdup(pattern),
+          let cPath = strdup(path) else {
+      fatalError("strdup returned null: Likely out of memory")
+    }
     defer {
       free(cPattern)
       free(cPath)

--- a/Tests/PathKitTests/PathKitSpec.swift
+++ b/Tests/PathKitTests/PathKitSpec.swift
@@ -290,12 +290,12 @@ describe("PathKit") {
       let current = Path.current
       let error = ThrowError()
 
-      try expect {
+      try expect({
         try Path("/usr/bin").chdir {
           try expect(Path.current) == Path("/usr/bin")
           throw error
         }
-      }.toThrow(error)
+      }).toThrow(error)
 
       try expect(Path.current) == current
     }
@@ -324,9 +324,9 @@ describe("PathKit") {
     $0.it("errors when you read from a non-existing file as NSData") {
       let path = Path("/tmp/pathkit-testing")
 
-      try expect {
+      try expect({
         try path.read() as Data
-      }.toThrow()
+      }).toThrow()
     }
 
     $0.it("can read a String from a file") {
@@ -339,9 +339,9 @@ describe("PathKit") {
     $0.it("errors when you read from a non-existing file as a String") {
       let path = Path("/tmp/pathkit-testing")
 
-      try expect {
+      try expect({
         try path.read() as String
-      }.toThrow()
+      }).toThrow()
     }
   }
 
@@ -364,9 +364,9 @@ describe("PathKit") {
       let path = Path("/")
       let data = "Hi".data(using: String.Encoding.utf8, allowLossyConversion: true)
 
-      try expect {
+      try expect({
         try path.write(data!)
-      }.toThrow()
+      }).toThrow()
       #endif
     }
 
@@ -384,9 +384,9 @@ describe("PathKit") {
       #else
       let path = Path("/")
 
-      try expect {
+      try expect({
         try path.write("hi")
-      }.toThrow()
+      }).toThrow()
       #endif
     }
   }


### PR DESCRIPTION
Based on @kylef's feedback for this similar PR: https://github.com/kylef/PathKit/pull/78

Also includes a fix for Xcode 12.5 ("ambiguous use of `expect`") referenced here: https://github.com/kylef/PathKit/pull/74#issuecomment-842159029